### PR TITLE
Fixes the not-a-tty error

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,10 +3,13 @@
 
 Vagrant.configure(2) do |config|
   config.vm.box = 'ubuntu/trusty32'
+  config.vm.box_check_update = false
 
   config.vm.network :private_network, ip: '192.168.50.100'
   config.vm.network :forwarded_port, guest: 3128, host: 3128 # Squid
   config.vm.network :forwarded_port, guest: 8080, host: 3128 # Squid
+
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
 
   # Configure a small VirtualBox system (we don't need much)
   config.vm.provider :virtualbox do |v|


### PR DESCRIPTION
Also removes update check since this is intended to be a static use
case, there's no need to update the base machine.
