### PR TITLE
fix provisioning order

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,14 +26,14 @@ Vagrant.configure(2) do |config|
     apt-get -y install nginx
   SHELL
 
-  config.vm.provision 'copy do-not-cache', type: 'shell', run: 'always', inline: <<-SHELL
-    [[ -f /vagrant/do-not-cache.txt ]] && cp /vagrant/do-not-cache.txt /etc/squid3/do-not-cache.txt
-  SHELL
-
   config.vm.provision 'Proxy Server', type: 'chef_solo' do |chef|
     chef.install = false
     chef.add_recipe "squid"
   end
+
+  config.vm.provision 'copy do-not-cache', type: 'shell', run: 'always', inline: <<-SHELL
+    [[ -f /vagrant/do-not-cache.txt ]] && cp /vagrant/do-not-cache.txt /etc/squid3/do-not-cache.txt
+  SHELL
 
   config.vm.provision 'Create PAC', type: 'shell', run: 'always', path: 'scripts/build_proxy.rb'
   config.vm.provision 'Start VPN',  type: 'shell', run: 'always', path: 'scripts/start_vpn.sh'


### PR DESCRIPTION
Vagrant runs the provisioning scripts in the order they are defined. This fix ensures that the squid directory exists in /etc before copying the file into it.
